### PR TITLE
Fix broken link on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## PC Medlink - Peace Corps Medical Supplies
 
-This project grew out of a [National Day of Civic Hacking](http://hackforchange.org/). You can see a live version of the site at [pcmedlink.org](pcmedlink.org).
+This project grew out of a [National Day of Civic Hacking](http://hackforchange.org/). You can see a live version of the site at [pcmedlink.org](http://pcmedlink.org).
 
 ### Developing locally
 


### PR DESCRIPTION
Just a minor fix in the markdown...

The current readme was pointing to `https://github.com/atlrug-rhok/medlink/blob/master/pcmedlink.org`
