### PR TITLE
add table_print to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   gem 'letter_opener'
   gem 'simplecov'
   gem 'coveralls', require: false
+  gem 'table_print', '~> 1.3.2'
 end
 
 gem 'rspec-rails', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
     sqlite3 (1.3.8)
     sucker_punch (1.0.1)
       celluloid (~> 0.14.1)
+    table_print (1.3.2)
     thor (0.18.1)
     thread_safe (0.1.2)
       atomic
@@ -267,6 +268,7 @@ DEPENDENCIES
   sms-spec
   sqlite3
   sucker_punch
+  table_print (~> 1.3.2)
   twilio-ruby
   uglifier
   unicorn


### PR DESCRIPTION
Hi all - @gmacie let me know that table_print had been breaking your repo.  Turns out the one little thing that I didn't properly namespace was conflicting with some Devise code.  table_print v1.3.2 fixes the naming conflict and thus the unable-to-log-in problem.  Sorry for the trouble! Oh and if you don't want this PR that's fine, just thought I'd make the gesture of fixing what I had broken but if you want to use table_print in a different way or not at all, no problem :) -Chris
