### PR TITLE
Closes #91

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,4 +44,10 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+
+  # Redirects to the login path to allow the flash messages to display for sign_out.
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
 end


### PR DESCRIPTION
Redirects to login path to allow flash messages for sign_out to display correctly.

I'm new to this code base and would appreciate another set of eyes.  It uses the default message from devise.en.yml:
      signed_out: "Signed out successfully."
