### PR TITLE
Closes #113 - adding remember_me services.  The user table already had t...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :test do
   gem 'cucumber-rails', :require => false
   gem 'database_cleaner', '1.0.1'
   gem 'selenium-webdriver'
+
+  gem 'show_me_the_cookies'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
       rubyzip (< 1.0.0)
       websocket (~> 1.0.4)
     sexp_processor (4.3.0)
+    show_me_the_cookies (2.1.0)
+      capybara (~> 2.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -278,6 +280,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   selenium-webdriver
+  show_me_the_cookies
   simplecov
   sms-spec
   sqlite3

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,6 +46,6 @@ class Admin::UsersController < AdminController
 
   def user_params
     params.require(:user).permit [:first_name, :last_name, :location,
-      :country_id, :phone, :email, :pcv_id, :role, :pcmo_id]
+      :country_id, :phone, :email, :pcv_id, :role, :pcmo_id, :remember_me]
   end
 end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,6 +6,9 @@
       = f.email_field :email, placeholder: 'email@email.com', class: 'input--full', autofocus: true
     .input-group
       = f.password_field :password, placeholder: 'Password', class: 'input--full'
+    .input-group
+      = f.check_box :remember_me
+      = f.label :remember_me
     .btn-group
       %button.btn.btn--primary(type="submit") Sign in
     = link_to 'Forgot Password', new_user_password_path, class: 'btn'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -115,7 +115,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.weeks
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false

--- a/features/Acceptance/remember_me.feature
+++ b/features/Acceptance/remember_me.feature
@@ -1,0 +1,31 @@
+Feature: Sign in
+  In order to get access to protected sections of the site
+  A user
+  Should be able to sign in
+
+  Background:
+    Given the default user exists
+
+  Scenario: User signs in successfully as ADMIN with remember me enabled
+    Given I am an "admin"
+    And I am not logged in
+    When I sign in with valid credentials after checking remember me
+    Then I see a successful sign in message
+    When I return to the site
+    Then I should be signed in as "admin"
+    When I close my browser (clearing the session)
+    And I return to the site
+    Then I should be signed in as "admin"
+
+
+  Scenario: User clears remember me cookie
+    Given I am an "admin"
+    And I am not logged in
+    When I sign in with valid credentials after checking remember me
+    Then I see a successful sign in message
+    When I return to the site
+    Then I should be signed in as "admin"
+    When I clear my remember me cookie and close my browser
+    And I return to the site
+    Then I should be signed out
+

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -32,10 +32,15 @@ def set_role(role)
   end
 end
 
-def sign_in
+def sign_in(remember=false)
   visit '/users/sign_in'
-  fill_in "email@email.com", :with => @visitor[:email]
-  fill_in "Password", :with => @visitor[:password]
+  fill_in "user_email", :with => @visitor[:email]
+  fill_in "user_password", :with => @visitor[:password]
+  if (remember)
+    check "user_remember_me"
+  else
+    uncheck "user_remember_me"
+  end
   click_button "Sign in"
 end
 
@@ -43,6 +48,7 @@ def delete_user
   @user ||= User.where('email' => @visitor[:email]).first
   @user.destroy unless @user.nil?
 end
+
 
 ### GIVEN ############################################################
 
@@ -88,6 +94,20 @@ end
 When /^I sign in with valid credentials$/ do
   create_visitor
   sign_in
+end
+
+
+When /^I sign in with valid credentials after checking remember me$/ do
+  sign_in(true)
+end
+
+When(/^I close my browser \(clearing the session\)$/) do
+  expire_cookies
+end
+
+When(/^I clear my remember me cookie and close my browser$/) do
+  expire_cookies
+  delete_cookie "remember_user_token"
 end
 
 When /^I sign out$/ do

--- a/features/support/cookies.rb
+++ b/features/support/cookies.rb
@@ -1,0 +1,3 @@
+# Loaded by cucumber and initializes the show me the cookies gem.
+# https://github.com/nruth/show_me_the_cookies
+World(ShowMeTheCookies)


### PR DESCRIPTION
...he required fields, so I didn't add a DB migration.

Enabled remember_me in devise config
Fixed selectors for the login test to use the element ID instead of the text.
Added show_me_the_cookies gem for cookie manipulation
Added new tests to cover positive and negative case
Added new support file for init'ting the new gem.
