### PR TITLE
Added code to remove existing orders from database before removing

### DIFF
--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -10,6 +10,8 @@ task :generate => :environment do
   supplies  = Supply.all
   orders    = 0
 
+  Order.all.select { |o| o.user.email =~ /peacecorps-demo.gov/ }.each &:destroy!
+
   generate_random_order = -> (pcv, date, fulfilled) do
     o = Order.new(
       user: pcv,


### PR DESCRIPTION
Added code to remove existing orders from database before removing current users to avoid having orders without associated users in the database. See https://github.com/atlrug-rhok/medlink/issues/249 for more details.
