### PR TITLE
Fix typo on Help page

### DIFF
--- a/app/views/partials/help.html.haml
+++ b/app/views/partials/help.html.haml
@@ -60,4 +60,4 @@
 %h2 If you get a problem with the software?
 %p Please create an email describing the steps to reproduce the software problem and email it to
 %a{href: "mailto:support@pcmedlink.org"} support mailing list.
-You will receive an acknowledgement and initial assessment without 24 hours.
+You will receive an acknowledgement and initial assessment within 24 hours.


### PR DESCRIPTION
Changed "without 24 hours" to "within 24 hours"
