### PR TITLE
Sets password reset and confirm to 30 days

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -102,7 +102,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 30.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
@@ -172,7 +172,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 30.days
 
   # ==> Configuration for :encryptable
   # Allow you to use another encryption algorithm besides bcrypt (default). You can use


### PR DESCRIPTION
Relates to Issue Extend account activation time #354

It appears that the welcome mailer is a password reset notification. Therefor I changed the config to allow confirm_within to 30 days as well as password reset to be 30 days. 

You may wish to consider changing this for security purposes down the line. Typical password reset times are something like 2 hours, I think!
