### PR TITLE
Make auto_archive check more defensive

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -28,6 +28,10 @@ class Response < ActiveRecord::Base
     end
   end
 
+  def auto_archivable?
+    orders.all? { |o| o.delivery_method && o.delivery_method.auto_archive? }
+  end
+
   private
 
   def supply_names

--- a/app/services/order_responder.rb
+++ b/app/services/order_responder.rb
@@ -9,9 +9,7 @@ class OrderResponder
     @response.send!
     @response.mark_updated_orders!
     @response.user.update_waiting!
-    if @response.orders.all? { |o| o.delivery_method.auto_archive? }
-      @response.archive!
-    end
+    @response.archive! if @response.auto_archivable?
   end
 
   private #----------


### PR DESCRIPTION
The substantial change here is simply to ensure we don't call `auto_archive?` on `nil` for orders with no delivery method.
