### PR TITLE
Add scheduling option message, and link to 'contact support'

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -15,7 +15,11 @@
       = f.select :hour, announcement.hour_choices, include_blank: !announcement.hour.present?
       - if announcement.preview
         .help-block Sent on #{announcement.preview}
-    - elsif announcement.schedule
+    - elsif announcement.preview
       h3 Scheduled Message
       p This message will be sent automatically every month - this month on #{announcement.preview}.
       p Please #{link_to "contact support", "mailto:support@pcmedlink.org"} to alter this schedule.
+    - else
+      h3
+      p Would you like to make this a reocurring message?
+      p Please #{link_to "contact support", "mailto:support@ocmedlink.org"} to set your announcement schedule


### PR DESCRIPTION
@jamesdabbs this pull request is for issue #493, dealing with scheduled announcement text displaying on non-scheduled announcements. In the announcements view, I've added text asking the user if they would like to make the message a reocurring message, as well as a link to contact support. 